### PR TITLE
SL-1301 update reporting_outcome calculation

### DIFF
--- a/jobs/sql/derivations/ncd_monthly_summary.sql
+++ b/jobs/sql/derivations/ncd_monthly_summary.sql
@@ -179,7 +179,7 @@ from ncd_monthly_summary_staging t;
 
 update t
 set calculated_reporting_outcome = IIF(
-	DATEDIFF(DAY, coalesce(t.latest_ncd_encounter_datetime, t.date_enrolled), t.reporting_date ) > 180
+	DATEDIFF(DAY, coalesce(cast(t.latest_ncd_encounter_datetime as DATE), t.date_enrolled), t.reporting_date ) > 180
 	and DATEDIFF(DAY, t.next_appointment_date, t.reporting_date ) > 90, 
 	'Lost to followup', null)
 from ncd_monthly_summary_staging t


### PR DESCRIPTION
Updated the calculation for 'calculated_reporting_outcome' to include the latest NCD encounter date in the condition. Renamed the staging table to the final summary table.